### PR TITLE
Add hard veto blackouts (Guru/Shukra Asta, Chaturmas, Kharmas, Adhika Maas) to the muhurta finder

### DIFF
--- a/backend/muhurta.py
+++ b/backend/muhurta.py
@@ -12,10 +12,15 @@ of the per-purpose tables, universal rules apply to every purpose:
   Bhadra-free portion remains.
 - Optional Chandrabalam (Moon-sign compatibility) and Tarabalam (birth
   nakshatra compatibility) for the native.
+- Hard veto blackouts per purpose (the rules mainstream panchangas such as
+  DrikPanchang apply before any day-quality scoring): Guru/Shukra Asta
+  (Jupiter/Venus combustion, padded by the Balya/Vriddha tara days),
+  Chaturmas (Devshayani Ekadashi to Devuthani Ekadashi), Kharmas/Malmas
+  (Sun in Dhanu or Meena) and Adhika Maas. A vetoed day scores 0
+  regardless of tithi/nakshatra/vara quality.
 
 We score each day 0-100 then rank. Deliberately out of scope at day-level
-granularity: lagna selection within the window, Guru/Shukra combustion
-blackout periods, Adhik Maas, and solar-month rules for specific samskaras.
+granularity: lagna selection within the window.
 """
 
 from __future__ import annotations
@@ -23,11 +28,20 @@ from __future__ import annotations
 from datetime import date as date_cls
 from datetime import datetime as dt_cls
 from datetime import timedelta
+from datetime import timezone as _timezone
+from functools import lru_cache as _lru_cache
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+import swisseph as swe
+
 from advanced_panchang import compute_detailed_panchang
+from ayanamsa import sidereal_context
 from constants import NAKSHATRAS
 from panchang_constants import GOOD_CHANDRA_OFFSETS, RASHI_NAMES
+from tyajyam import (
+    _GURU_ASTHAMANAM_ORB,
+    _SUKRA_ASTHAMANAM_ORB_RETRO,
+)
 
 # ---- Rule-table building blocks ----
 # Tithi ids 1-30 (1-15 Shukla, 15=Purnima, 16-30 Krishna, 30=Amavasya).
@@ -61,9 +75,213 @@ _W_BHADRA = -15
 # A trimmed Bhadra-free window shorter than this is treated as unusable.
 _MIN_WINDOW_MINUTES = 30
 
+# ---- Veto rules (hard blackouts, applied before scoring) ----
+# Purposes opt in via a "vetoes" set with any of: "combust", "chaturmas",
+# "kharmas", "adhika". A triggered veto forces the day's score to 0. These
+# are the blackout rules mainstream panchangas (DrikPanchang et al.) apply
+# before any day-quality scoring.
+
+# Panchangas extend the combustion blackout by ~3 days on each side
+# (Vriddha tara before setting, Balya tara after rising).
+_TARA_BALA_PAD_DAYS = 3.0
+# Direct (superior-conjunction side) Venus is bright enough to be seen at
+# ~6 deg from the Sun, so published udaya/asta dates (DrikPanchang et al.)
+# correspond to a tighter orb than the classical 10 deg used for display
+# in the Dosha Tyajyam panel.
+_MUHURTA_SHUKRA_ORB_DIRECT = 6.0
+# Kharmas / Malmas: Sun in Dhanu (9) or Meena (12) - no shubha samskaras.
+_KHARMAS_SUN_SIGNS = {9, 12}
+
+_SYNODIC_MONTH = 29.530589  # days
+_MEAN_ELONGATION_RATE = 360.0 / _SYNODIC_MONTH  # Moon-Sun, degrees/day
+_MEAN_SUN_RATE = 360.0 / 365.2422  # degrees/day
+
+
+def _moon_sun_elongation(jd: float) -> float:
+    """Tropical Moon-Sun elongation in [0, 360). Tithi n spans
+    [(n-1)*12, n*12); new moon at 0, Shukla Ekadashi begins at 120."""
+    moon = swe.calc_ut(jd, swe.MOON, swe.FLG_SWIEPH)[0][0]
+    sun = swe.calc_ut(jd, swe.SUN, swe.FLG_SWIEPH)[0][0]
+    return (moon - sun) % 360.0
+
+
+def _elongation_crossing(jd_guess: float, target: float) -> float:
+    """JD where Moon-Sun elongation reaches `target` deg, nearest jd_guess.
+    Newton iteration on the mean rate; elongation grows ~11-15 deg/day so a
+    handful of steps converges to well under a minute."""
+    jd = jd_guess
+    for _ in range(8):
+        diff = (_moon_sun_elongation(jd) - target + 180.0) % 360.0 - 180.0
+        if abs(diff) < 1e-4:
+            break
+        jd -= diff / _MEAN_ELONGATION_RATE
+    return jd
+
+
+def _prev_new_moon(jd: float) -> float:
+    """JD of the last new moon at or before jd."""
+    nm = _elongation_crossing(jd - _moon_sun_elongation(jd) / _MEAN_ELONGATION_RATE, 0)
+    while nm > jd:
+        nm = _elongation_crossing(nm - _SYNODIC_MONTH, 0)
+    return nm
+
+
+def _sun_sidereal(jd: float) -> float:
+    with sidereal_context("lahiri"):
+        return swe.calc_ut(jd, swe.SUN, swe.FLG_SWIEPH | swe.FLG_SIDEREAL)[0][0]
+
+
+def _sankranti_jd(year: int, target_long: float) -> float:
+    """JD when the sidereal Sun reaches target_long (a sign boundary) in the
+    given Gregorian year. Seeks forward from Jan 1 so the crossing found is
+    this year's, then refines with Newton steps."""
+    jd = swe.julday(year, 1, 1, 0.0)
+    jd += ((target_long - _sun_sidereal(jd)) % 360.0) / _MEAN_SUN_RATE
+    for _ in range(10):
+        diff = (_sun_sidereal(jd) - target_long + 180.0) % 360.0 - 180.0
+        if abs(diff) < 1e-4:
+            break
+        jd -= diff / _MEAN_SUN_RATE
+    return jd
+
+
+def _sankranti_between(jd1: float, jd2: float) -> bool:
+    """True when the sidereal Sun crosses a 30-degree sign boundary in
+    (jd1, jd2). A lunar month with no sankranti is Adhika (intercalary)."""
+    l1, l2 = _sun_sidereal(jd1), _sun_sidereal(jd2)
+    travelled = (l2 - l1) % 360.0
+    into_sign = l1 % 30.0
+    return travelled >= (30.0 - into_sign)
+
+
+@_lru_cache(maxsize=32)
+def _chaturmas_span(year: int) -> Tuple[float, float]:
+    """(start_jd, end_jd) of Chaturmas for the year: start of Devshayani
+    Ekadashi (Ashadha Shukla 11) to end of Devuthani Ekadashi (Kartika
+    Shukla 11). Amanta months are anchored by the sankranti they contain:
+    Ashadha holds Karka sankranti, Kartika holds Vrishchika sankranti."""
+    spans = []
+    for sank_long, ek_target in ((90.0, 120.0), (210.0, 132.0)):
+        sank = _sankranti_jd(year, sank_long)
+        nm = _prev_new_moon(sank)
+        spans.append(
+            _elongation_crossing(nm + ek_target / _MEAN_ELONGATION_RATE, ek_target)
+        )
+    return spans[0], spans[1]
+
+
+@_lru_cache(maxsize=512)
+def _is_adhika_day(jd_day: int) -> bool:
+    """True when the lunar month containing this day (integer JD) has no
+    sankranti - an Adhika Maas, barred for shubha karya."""
+    nm = _prev_new_moon(float(jd_day))
+    nm_next = _elongation_crossing(nm + _SYNODIC_MONTH, 0)
+    return not _sankranti_between(nm, nm_next)
+
+
+@_lru_cache(maxsize=512)
+def _combust_labels(jd_day: int) -> Tuple[str, ...]:
+    """Guru/Shukra Asta labels active within _TARA_BALA_PAD_DAYS of the day
+    (integer JD). The pad reproduces the Vriddha/Balya tara blackout that
+    panchangas add around the combustion window itself."""
+    labels = []
+    sample_jds = (
+        float(jd_day) - _TARA_BALA_PAD_DAYS,
+        float(jd_day),
+        float(jd_day) + _TARA_BALA_PAD_DAYS,
+    )
+    for planet_id, label in (
+        (swe.JUPITER, "Guru Asta (Jupiter combust)"),
+        (swe.VENUS, "Shukra Asta (Venus combust)"),
+    ):
+        for jd in sample_jds:
+            sun_lon = swe.calc_ut(jd, swe.SUN, swe.FLG_SWIEPH)[0][0]
+            pos = swe.calc_ut(jd, planet_id, swe.FLG_SWIEPH | swe.FLG_SPEED)[0]
+            lon, speed = pos[0], pos[3]
+            if planet_id == swe.JUPITER:
+                orb = _GURU_ASTHAMANAM_ORB
+            else:
+                orb = (
+                    _SUKRA_ASTHAMANAM_ORB_RETRO
+                    if speed < 0
+                    else _MUHURTA_SHUKRA_ORB_DIRECT
+                )
+            elongation = abs((lon - sun_lon + 180.0) % 360.0 - 180.0)
+            if elongation <= orb:
+                labels.append(label)
+                break
+    return tuple(labels)
+
+
+def _sunrise_jd(panch: Dict[str, Any]) -> Optional[float]:
+    sunrise = panch.get("sun_moon", {}).get("sunrise")
+    if not sunrise:
+        return None
+    utc = dt_cls.fromisoformat(sunrise).astimezone(_timezone.utc)
+    return swe.julday(
+        utc.year, utc.month, utc.day, utc.hour + utc.minute / 60 + utc.second / 3600
+    )
+
+
+def _veto_reasons(panch: Dict[str, Any], purpose_cfg: Dict[str, Any]) -> List[str]:
+    """Blackout reasons for the day, empty when the day is workable."""
+    vetoes = purpose_cfg.get("vetoes", set())
+    reasons: List[str] = []
+    if not vetoes:
+        return reasons
+    jd = _sunrise_jd(panch)
+    if jd is None:
+        return reasons
+    if "combust" in vetoes:
+        for label in _combust_labels(round(jd)):
+            reasons.append(f"{label} - event prohibited")
+    if "kharmas" in vetoes:
+        sun_sign = panch["rashi_nakshatra"]["sunsign"]["index"]
+        if sun_sign in _KHARMAS_SUN_SIGNS:
+            reasons.append(
+                f"Kharmas (Sun in {RASHI_NAMES[sun_sign - 1]}) - prohibited solar month"
+            )
+    if "chaturmas" in vetoes:
+        # Chaturmas never straddles a Gregorian year boundary (Jul-Nov).
+        utc_year = swe.revjul(jd)[0]
+        start, end = _chaturmas_span(utc_year)
+        if start <= jd < end:
+            reasons.append(
+                "Chaturmas (Devshayani to Devuthani Ekadashi) - event prohibited"
+            )
+    if "adhika" in vetoes and _is_adhika_day(round(jd)):
+        reasons.append("Adhika Maas (intercalary month) - event prohibited")
+    return reasons
+
+
 # ---- Purpose rules ----
 
 PURPOSES: Dict[str, Dict[str, Any]] = {
+    "marriage": {
+        "label": "Marriage (Vivaha)",
+        "good_tithis": _both_pakshas(2, 3, 5, 7, 10, 11, 12, 13),
+        # Classical Vivaha star set per Muhurta Chintamani.
+        "good_nakshatras": _naks(
+            "Rohini",
+            "Mrigashira",
+            "Magha",
+            "Uttara Phalguni",
+            "Hasta",
+            "Swati",
+            "Anuradha",
+            "Mula",
+            "Uttara Ashadha",
+            "Shravana",
+            "Uttara Bhadrapada",
+            "Revati",
+        ),
+        "good_weekdays": {MON, WED, THU, FRI},
+        # No hard weekday avoidance: published vivaha lists (DrikPanchang
+        # et al.) freely include Tue/Sat/Sun dates when the stars fit.
+        "avoid_weekdays": set(),
+        "bad_tithis": RIKTA_TITHIS | {AMAVASYA},
+        "vetoes": {"combust", "chaturmas", "kharmas", "adhika"},
+    },
     "engagement": {
         "label": "Engagement (Sagai / Vagdana)",
         # Betrothal uses the classical Vivaha star set.
@@ -85,6 +303,7 @@ PURPOSES: Dict[str, Dict[str, Any]] = {
         "good_weekdays": {MON, WED, THU, FRI},
         "avoid_weekdays": {TUE, SAT, SUN},
         "bad_tithis": RIKTA_TITHIS | {AMAVASYA},
+        "vetoes": {"combust", "chaturmas", "kharmas", "adhika"},
     },
     "griha_pravesh": {
         "label": "Griha Pravesha (Housewarming)",
@@ -108,6 +327,7 @@ PURPOSES: Dict[str, Dict[str, Any]] = {
         "good_weekdays": {MON, WED, THU, FRI},
         "avoid_weekdays": {TUE, SUN},
         "bad_tithis": RIKTA_TITHIS | {PURNIMA, AMAVASYA},
+        "vetoes": {"combust", "chaturmas", "kharmas", "adhika"},
     },
     "bhoomi_pujan": {
         "label": "Bhoomi Pujan (Foundation / Griharambha)",
@@ -131,6 +351,7 @@ PURPOSES: Dict[str, Dict[str, Any]] = {
         "good_weekdays": {MON, WED, THU, FRI},
         "avoid_weekdays": {TUE, SAT, SUN},
         "bad_tithis": RIKTA_TITHIS | {AMAVASYA},
+        "vetoes": {"combust", "kharmas", "adhika"},
     },
     "property_purchase": {
         "label": "Property Purchase (Land / House)",
@@ -472,6 +693,11 @@ def score_day(
     vara_name = panch["vara"]["sanskrit"]
     moon_sign_id = panch["rashi_nakshatra"]["moonsign"]["index"]
 
+    # Hard vetoes: combustion / Chaturmas / Kharmas / Adhika blackouts kill
+    # the day outright - no tithi/nakshatra quality can rescue it.
+    veto = _veto_reasons(panch, purpose_cfg)
+    reasons_bad.extend(veto)
+
     # Tithi
     if tithi_idx in purpose_cfg.get("bad_tithis", set()):
         score += _W_BAD_TITHI
@@ -533,11 +759,12 @@ def score_day(
         elif tbal == 0:
             reasons_bad.append("Inauspicious Tarabalam for native's birth-nakshatra")
 
-    score = max(0, min(100, score))
+    score = 0 if veto else max(0, min(100, score))
 
     aus = panch["auspicious_timings"]
     result: Dict[str, Any] = {
         "score": score,
+        "vetoed": bool(veto),
         "reasons": reasons,
         "cautions": reasons_bad,
         "tithi": tithi_name,

--- a/backend/tests/compare_drik.py
+++ b/backend/tests/compare_drik.py
@@ -1,0 +1,129 @@
+"""Compare the local muhurta finder against DrikPanchang's published lists.
+
+Run from backend/ with the venv active:
+
+    python tests/compare_drik.py
+
+Reference data below is transcribed from
+https://www.drikpanchang.com/shubh-dates/shubh-marriage-dates-with-muhurat.html
+(New Delhi, 2026). Update DRIK_MARRIAGE_2026 if you re-check the source.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from muhurta import find_muhurtas  # noqa: E402
+
+DELHI = {"latitude": 28.6139, "longitude": 77.2090, "timezone_name": "Asia/Kolkata"}
+
+# DrikPanchang marriage muhurat dates for New Delhi, 2026 (full year).
+DRIK_MARRIAGE_2026 = {
+    "2026-02-05",
+    "2026-02-06",
+    "2026-02-08",
+    "2026-02-10",
+    "2026-02-12",
+    "2026-02-14",
+    "2026-02-19",
+    "2026-02-20",
+    "2026-02-21",
+    "2026-02-24",
+    "2026-02-25",
+    "2026-02-26",
+    "2026-03-02",
+    "2026-03-03",
+    "2026-03-04",
+    "2026-03-07",
+    "2026-03-08",
+    "2026-03-09",
+    "2026-03-11",
+    "2026-03-12",
+    "2026-04-15",
+    "2026-04-20",
+    "2026-04-21",
+    "2026-04-25",
+    "2026-04-26",
+    "2026-04-27",
+    "2026-04-28",
+    "2026-04-29",
+    "2026-05-01",
+    "2026-05-03",
+    "2026-05-05",
+    "2026-05-06",
+    "2026-05-07",
+    "2026-05-08",
+    "2026-05-13",
+    "2026-05-14",
+    "2026-06-21",
+    "2026-06-22",
+    "2026-06-23",
+    "2026-06-24",
+    "2026-06-25",
+    "2026-06-26",
+    "2026-06-27",
+    "2026-06-29",
+    "2026-07-01",
+    "2026-07-06",
+    "2026-07-07",
+    "2026-07-11",
+    "2026-11-21",
+    "2026-11-24",
+    "2026-11-25",
+    "2026-11-26",
+    "2026-12-02",
+    "2026-12-03",
+    "2026-12-04",
+    "2026-12-05",
+    "2026-12-06",
+    "2026-12-11",
+    "2026-12-12",
+}
+
+
+def month_range(year: int, month: int):
+    from calendar import monthrange
+
+    last = monthrange(year, month)[1]
+    return f"{year}-{month:02d}-01", f"{year}-{month:02d}-{last:02d}"
+
+
+def main() -> int:
+    year = 2026
+    print(f"Marriage muhurta comparison vs DrikPanchang, New Delhi {year}")
+    print(f"{'Month':<6} {'Drik':>4} {'Ours':>4}  extra-vs-drik / missed-vs-drik")
+    print("-" * 78)
+
+    total_extra, total_missed = 0, 0
+    for month in range(1, 13):
+        start, end = month_range(year, month)
+        res = find_muhurtas("marriage", start, end, **DELHI)
+        ours = {m["date"] for m in res["muhurtas"]}
+        drik = {d for d in DRIK_MARRIAGE_2026 if d.startswith(f"{year}-{month:02d}")}
+        extra = sorted(ours - drik)
+        missed = sorted(drik - ours)
+        total_extra += len(extra)
+        total_missed += len(missed)
+        flag = "" if not extra and not missed else "  <-- diff"
+        print(
+            f"{start[:7]:<6} {len(drik):>4} {len(ours):>4}  "
+            f"+{[d[8:] for d in extra]} / -{[d[8:] for d in missed]}{flag}"
+        )
+
+    print("-" * 78)
+    print(f"days we list that Drik rejects: {total_extra}")
+    print(f"days Drik lists that we reject: {total_missed}")
+    print(
+        "\nNote: exact parity is not expected. Drik additionally applies "
+        "lagna shuddhi,\nBalya/Vriddha tara periods around combustion, and "
+        "regional month rules. The\nveto rules should eliminate the big "
+        "blocks (Jul 12+, Aug-Nov 20, Kharmas)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_muhurta.py
+++ b/backend/tests/test_muhurta.py
@@ -170,13 +170,14 @@ def test_new_purposes_listed():
     """The purposes added for house/ceremony coverage must be exposed."""
     ids = {x["id"] for x in list_purposes()}
     assert {
+        "marriage",
         "engagement",
         "property_purchase",
         "bhoomi_pujan",
         "annaprashana",
         "gold_purchase",
     }.issubset(ids)
-    assert len(ids) == 12
+    assert len(ids) == 13
 
 
 def test_rule_tables_consistent():

--- a/backend/tests/test_muhurta_vetoes.py
+++ b/backend/tests/test_muhurta_vetoes.py
@@ -1,0 +1,92 @@
+"""Veto blackout rules in the muhurta finder.
+
+Anchors are 2026 events cross-checked against DrikPanchang (New Delhi):
+- Guru Asta (Jupiter combust): dates blocked from Jul 12, 2026
+- Chaturmas: Devshayani Ekadashi Jul 24, 2026 to Devuthani Ekadashi Nov 20, 2026
+- Kharmas: Sun in Dhanu from Dec 16, 2026; Sun in Meena Mar 15 - Apr 13, 2026
+- Adhika Jyeshtha: May 17 - Jun 14, 2026
+- Shukra Asta around the Jan 6, 2026 superior conjunction: marriage dates
+  resume Feb 5, 2026
+"""
+
+import sys
+from pathlib import Path
+
+import swisseph as swe
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from muhurta import (  # noqa: E402
+    _chaturmas_span,
+    _combust_labels,
+    _is_adhika_day,
+    find_muhurtas,
+)
+
+DELHI = dict(latitude=28.6139, longitude=77.2090, timezone_name="Asia/Kolkata")
+
+
+def _day_result(res, iso_date):
+    return next(d for d in res["all_days"] if d["date"] == iso_date)
+
+
+def _jd(y, m, d, h=6.0):
+    return round(swe.julday(y, m, d, h))
+
+
+def test_chaturmas_span_2026():
+    start, end = _chaturmas_span(2026)
+    sy, sm, sd, _ = swe.revjul(start)
+    ey, em, ed, _ = swe.revjul(end)
+    assert (sy, sm, sd) == (2026, 7, 24)  # Devshayani Ekadashi begins
+    assert (ey, em, ed) == (2026, 11, 21)  # Devuthani Ekadashi ends (01:03 UT)
+
+
+def test_chaturmas_vetoes_marriage_but_kartika_dwadashi_is_free():
+    res = find_muhurtas("marriage", "2026-11-15", "2026-11-25", **DELHI)
+    vetoed = _day_result(res, "2026-11-19")
+    assert vetoed["vetoed"] and vetoed["score"] == 0
+    assert any("Chaturmas" in c for c in vetoed["cautions"])
+    free = _day_result(res, "2026-11-21")  # Drik's first post-Chaturmas date
+    assert not free["vetoed"]
+
+
+def test_guru_asta_blocks_mid_july_2026():
+    labels_jul_16 = _combust_labels(_jd(2026, 7, 16))
+    assert any("Guru Asta" in x for x in labels_jul_16)
+    labels_jul_8 = _combust_labels(_jd(2026, 7, 8))
+    assert not any("Guru Asta" in x for x in labels_jul_8)
+
+
+def test_shukra_asta_clears_by_feb_5_2026():
+    assert any("Shukra Asta" in x for x in _combust_labels(_jd(2026, 1, 25)))
+    assert not any("Shukra Asta" in x for x in _combust_labels(_jd(2026, 2, 5)))
+
+
+def test_kharmas_vetoes_late_december():
+    res = find_muhurtas("marriage", "2026-12-15", "2026-12-25", **DELHI)
+    kharmas = _day_result(res, "2026-12-20")
+    assert kharmas["vetoed"]
+    assert any("Kharmas" in c for c in kharmas["cautions"])
+
+
+def test_adhika_jyeshtha_2026():
+    assert _is_adhika_day(_jd(2026, 5, 25))
+    assert _is_adhika_day(_jd(2026, 6, 10))
+    assert not _is_adhika_day(_jd(2026, 6, 20))
+    assert not _is_adhika_day(_jd(2026, 5, 10))
+
+
+def test_marriage_july_2026_matches_drik_block():
+    """After Jul 11 there must be no marriage muhurta until Chaturmas ends
+    (Guru Asta from Jul 12, then Devshayani from Jul 24) - per DrikPanchang."""
+    res = find_muhurtas("marriage", "2026-07-01", "2026-07-31", **DELHI)
+    listed = {m["date"] for m in res["muhurtas"]}
+    assert not any(d >= "2026-07-12" for d in listed)
+    assert "2026-07-01" in listed and "2026-07-06" in listed
+
+
+def test_purpose_without_vetoes_unaffected_by_chaturmas():
+    res = find_muhurtas("travel", "2026-08-01", "2026-08-10", **DELHI)
+    assert res["total_matches"] > 0
+    assert not any(d.get("vetoed") for d in res["all_days"])


### PR DESCRIPTION
## Problem

The muhurta finder scores days on tithi/nakshatra/vara only, so it recommends dates inside periods that classical muhurta (and mainstream panchangas like DrikPanchang) prohibit outright. For marriage in July 2026 (New Delhi) it returned 23 dates where DrikPanchang lists 4 - including dates during Guru Asta (Jupiter combust, Jul 12+) and Chaturmas (Jul 24 onward). The module docstring noted these rules as deliberately out of scope; this PR brings them in scope.

## What this adds

**Hard veto layer in `backend/muhurta.py`** - purposes opt in via a `"vetoes"` set; any triggered veto forces the day's score to 0 and surfaces the reason in `cautions`, plus a new `vetoed` flag on each day result:

- **Guru/Shukra Asta** - Sun-planet elongation via Swiss Ephemeris. Jupiter uses the classical 11 deg orb (shared with tyajyam's Dosha Tyajyam); Venus uses 8 deg retrograde / 6 deg direct - the direct orb is calibrated against published udaya dates, since bright Venus near superior conjunction is visible at ~6 deg (2026: DrikPanchang resumes marriage dates Feb 5, when Venus is at 7.0 deg; the classical 10 deg orb would block until Feb 19). Padded 3 days each side for the Balya/Vriddha tara convention.
- **Chaturmas** - Devshayani Ekadashi to Devuthani Ekadashi, computed precisely: find the Karka/Vrishchika sankranti, the new moon preceding it, then the Ekadashi elongation crossing of that lunation. The existing approximate sun-sign month label drifts up to two weeks at month boundaries, so it could not anchor this. Computed span for 2026: Jul 24 03:43 UT to Nov 21 01:03 UT, matching published dates to the day.
- **Kharmas/Malmas** - Sun in Dhanu or Meena (sidereal, from the existing panchang sunsign).
- **Adhika Maas** - lunation containing no sankranti (2026: Adhika Jyeshtha, May 17 - Jun 14).

**New `marriage` purpose** - classical Vivaha tithi/nakshatra tables, vetoes enabled. Vetoes are also wired onto `engagement`, `griha_pravesh` and `bhoomi_pujan`. Other purposes (travel, business, medical, ...) are unaffected.

## Verification

`backend/tests/compare_drik.py` diffs the finder against DrikPanchang's published 2026 marriage calendar for New Delhi, month by month. After this change every prohibited block matches to the day (January, Jul 12+, August-November 20, late December, Adhika Jyeshtha), and 57 of DrikPanchang's 59 dates are found. Remaining extras are days DrikPanchang excludes via lagna-level analysis, which stays out of scope for this day-level scorer.

- `backend/tests/test_muhurta_vetoes.py` pins the 2026 anchors (Chaturmas boundaries, Guru Asta from Jul 12, Shukra Asta clearing by Feb 5, Kharmas, Adhika Jyeshtha, and a no-veto purpose staying unaffected).
- Existing suite: 27 muhurta/tyajyam tests pass; `test_new_purposes_listed` updated for the 13th purpose.
- `ruff check` and `ruff format` clean.

All astronomical math goes through swisseph; sidereal calls use the `sidereal_context("lahiri")` wrapper. Sankranti/Ekadashi/lunation lookups are lru_cached so the per-day cost in `find_muhurtas` is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)