### PR TITLE
Add optional API-key auth and third-party CORS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,5 @@ memory/test_credentials.md
 android-sdk/frontend/node_modules/.cache/default-development/0.pack
 
 backend/.env
+backend/.env.local
 frontend/.env.production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,30 @@ vedicpanchanga.com/
 
 The frontend calls these directly via same-origin `/api/` (Nginx proxy in prod, Vite proxy in dev).
 
+### Third-party API access (optional API keys)
+
+The API is open by default. To grant external clients (mobile apps, other
+domains) access, set `API_KEYS` (comma-separated) in `backend/.env.local`
+on the server - that file is gitignored and never rewritten by
+`setup-vps.sh`, so keys survive deploys. Clients authenticate with either
+header:
+
+```
+Authorization: Bearer <key>
+X-API-Key: <key>
+```
+
+- The site's own frontend needs no key: requests whose `Origin` (or
+  `Referer`, for same-origin GETs) matches `AUTH_EXEMPT_ORIGINS`
+  (default: vedicpanchanga.com + localhost dev) skip the check, as do
+  `/api/` and `/api/health` (monitoring probes).
+- Browser-based third-party apps (Flutter Web, React, ...) additionally
+  need their origin added to `CORS_ORIGINS` (overridable in `.env.local`).
+  Preflight `OPTIONS` is answered by CORSMiddleware before auth runs and
+  allows `Content-Type, Authorization, X-API-Key` with `max_age=86400`.
+- Generate keys with `python3 -c "import secrets; print(secrets.token_urlsafe(32))"`.
+- Logic: `backend/auth.py`. Tests: `backend/tests/test_api_auth.py`.
+
 ---
 
 ## 5. Coding Standards
@@ -162,7 +186,7 @@ pytest tests/test_muhurta.py -v              # single suite
   panchang reference data (Kelowna), ayanamsa variants, varjyam/amrit/siddhi yogas,
   muhurta unit + HTTP, Gowri panchangam, Hora, Tyajyam, Tamil calendar,
   planetary transits, dasha sub-periods, Jaimini karakas, friendships,
-  Kalsarpa yoga, PDF rendering.
+  Kalsarpa yoga, PDF rendering, API-key auth + CORS preflight.
 
 ### Test Rules
 - Never reduce test count. If you refactor, migrate tests - don't delete them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ ruff check . --fix                                # lint + auto-fix
 ruff format .                                     # format - write
 ruff format --check .                             # format check (CI)
 ```
-- Reads `CORS_ORIGINS` from `backend/.env` (optional, defaults to `*`). No MongoDB required.
+- Reads `CORS_ORIGINS` from `backend/.env` (optional, defaults to `*`). No MongoDB required. `backend/.env.local` (gitignored, loaded on top with override) is where server-side secrets go - `setup-vps.sh` rewrites `.env` on every deploy but never touches `.env.local`.
+- Optional third-party API-key auth lives in `auth.py`: `API_KEYS` (comma-separated, unset = open API) + `AUTH_EXEMPT_ORIGINS` (own-site origins that stay keyless, defaults to vedicpanchanga.com + localhost dev), both read per-request. Clients send `Authorization: Bearer <key>` or `X-API-Key: <key>`; browser apps also need their origin in `CORS_ORIGINS`. `/api/` and `/api/health` stay open for monitoring. See `AGENTS.md` §4.
 - Swiss Ephemeris data files live in `backend/ephe/` (`*.se1`). Calculations silently fail without them; never delete or move this directory.
 - Must bind to `127.0.0.1` only in production. Never expose 8001 publicly (see `AGENTS.md` §8).
 - The CPU-bound endpoints (`/calculate`, `/get-panchang`, `/find-muhurta`) are plain `def` handlers so FastAPI runs them in its threadpool - keeps the event loop responsive under concurrent load.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ ruff check . --fix                                # lint + auto-fix
 ruff format .                                     # format - write
 ruff format --check .                             # format check (CI)
 ```
-- Reads `CORS_ORIGINS` from `backend/.env` (optional, defaults to `*`). No MongoDB required. `backend/.env.local` (gitignored, loaded on top with override) is where server-side secrets go - `setup-vps.sh` rewrites `.env` on every deploy but never touches `.env.local`.
+- Reads `CORS_ORIGINS` from `backend/.env` (untracked; `make install` seeds it from `backend/.env.example`, and the code falls back to vedicpanchanga.com + localhost:3121 when absent). No MongoDB required. `backend/.env.local` (gitignored, loaded on top with override) is where server-side secrets go - `setup-vps.sh` rewrites `.env` on every deploy but never touches `.env.local`.
 - Optional third-party API-key auth lives in `auth.py`: `API_KEYS` (comma-separated, unset = open API) + `AUTH_EXEMPT_ORIGINS` (own-site origins that stay keyless, defaults to vedicpanchanga.com + localhost dev), both read per-request. Clients send `Authorization: Bearer <key>` or `X-API-Key: <key>`; browser apps also need their origin in `CORS_ORIGINS`. `/api/` and `/api/health` stay open for monitoring. See `AGENTS.md` §4.
 - Swiss Ephemeris data files live in `backend/ephe/` (`*.se1`). Calculations silently fail without them; never delete or move this directory.
 - Must bind to `127.0.0.1` only in production. Never expose 8001 publicly (see `AGENTS.md` §8).

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ PYTEST  := backend/venv/bin/pytest
 RUFF    := backend/venv/bin/ruff
 UVICORN := backend/venv/bin/uvicorn
 
+# Interpreter used to CREATE the venv. On some macOS setups `python3` is the
+# CommandLineTools 3.9 (which once produced a broken hybrid venv here), so
+# prefer Homebrew's 3.14 when present. Override: make install VENV_PY=...
+VENV_PY ?= $(shell command -v python3.14 2>/dev/null || command -v python3)
+
 NPM := npm --prefix frontend
 
 # ---- Discoverability ------------------------------------------------------
@@ -32,9 +37,10 @@ help:  ## Show this help (default target).
 install: install-backend install-frontend install-hooks  ## First-time setup: venv, npm deps, git hooks.
 
 .PHONY: install-backend
-install-backend:  ## Create backend venv and install Python deps.
-	test -d backend/venv || python3 -m venv backend/venv
+install-backend:  ## Create backend venv, install Python deps, seed .env.
+	test -d backend/venv || $(VENV_PY) -m venv backend/venv
 	$(PIP) install -r backend/requirements.txt
+	test -f backend/.env || cp backend/.env.example backend/.env
 
 .PHONY: install-frontend
 install-frontend:  ## Install frontend npm deps.

--- a/backend/.env
+++ b/backend/.env
@@ -1,5 +1,0 @@
-# Backend env (development)
-# CORS_ORIGINS is a comma-separated allowlist for the FastAPI CORS middleware.
-# Development: allow the Vite dev server only.
-# Production:  setup-vps.sh writes a separate .env with vedicpanchanga.com.
-CORS_ORIGINS=http://localhost:3121,http://127.0.0.1:3121

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,22 @@
+# Backend env (development defaults).
+# `make install` copies this to backend/.env if one doesn't exist; setup-vps.sh
+# writes the production .env on the server. Both are gitignored - real config
+# never lives in git.
+
+# CORS_ORIGINS: comma-separated allowlist for the FastAPI CORS middleware.
+# Development: the Vite dev server. Production (written by setup-vps.sh):
+# vedicpanchanga.com. Add third-party browser-app origins here when granting
+# them API keys.
+CORS_ORIGINS=http://localhost:3121,http://127.0.0.1:3121
+
+# Optional API-key auth (see backend/auth.py). Unset = API fully open.
+# Comma-separated keys; clients send "Authorization: Bearer <key>" or
+# "X-API-Key: <key>". Generate one with:
+#   python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+# On the server, put real keys in backend/.env.local - it is gitignored,
+# loaded on top of .env, and never rewritten by setup-vps.sh.
+#API_KEYS=
+
+# Origins allowed to call without a key (the site's own frontend).
+# Defaults to vedicpanchanga.com + localhost dev; override only if needed.
+#AUTH_EXEMPT_ORIGINS=

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,98 @@
+"""Optional API-key authentication for the /api routes.
+
+Enabled by setting the ``API_KEYS`` env var (comma-separated list of keys).
+When it is empty or unset the API stays fully open - exactly the behavior
+before this module existed - so local dev and the current production deploy
+are unaffected until keys are configured.
+
+When keys are configured, a request passes if any of these hold:
+
+* it carries a valid key in ``Authorization: Bearer <key>`` or ``X-API-Key``,
+* its ``Origin`` (or, for same-origin GETs that omit Origin, its ``Referer``)
+  matches ``AUTH_EXEMPT_ORIGINS`` - the site's own frontend keeps working
+  without a key,
+* it targets an exempt liveness path (``/api/``, ``/api/health``) so
+  monitoring probes never need credentials.
+
+CORS preflight (``OPTIONS``) never reaches this dependency: CORSMiddleware
+answers it before routing, as the CORS spec requires (preflights carry no
+credentials).
+
+Honest scope note: the origin exemption trusts browser-controlled headers,
+which non-browser clients can spoof. Since the API was fully public before,
+this does not weaken anything - keys exist to grant/track third-party access
+(mobile apps, other domains), not to harden the first-party path.
+
+Env vars are read per-request (parsing a short string is negligible) so keys
+can be tested with monkeypatch and rotated with a plain service restart.
+"""
+
+import hmac
+import os
+
+from fastapi import HTTPException, Request
+
+# Liveness endpoints stay open even with keys configured.
+EXEMPT_PATHS = {"/api", "/api/", "/api/health"}
+
+_DEFAULT_EXEMPT_ORIGINS = (
+    "https://vedicpanchanga.com,https://www.vedicpanchanga.com,"
+    "http://localhost:3121,http://127.0.0.1:3121"
+)
+
+
+def _csv_env(name: str, default: str = "") -> list[str]:
+    raw = os.environ.get(name, default)
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def configured_keys() -> list[str]:
+    return _csv_env("API_KEYS")
+
+
+def exempt_origins() -> list[str]:
+    return [
+        o.rstrip("/").lower()
+        for o in _csv_env("AUTH_EXEMPT_ORIGINS", _DEFAULT_EXEMPT_ORIGINS)
+    ]
+
+
+def _extract_key(request: Request) -> str:
+    auth = request.headers.get("authorization", "")
+    scheme, _, token = auth.partition(" ")
+    if scheme.lower() == "bearer" and token.strip():
+        return token.strip()
+    return request.headers.get("x-api-key", "").strip()
+
+
+def _is_exempt_origin(request: Request) -> bool:
+    allowed = exempt_origins()
+    origin = request.headers.get("origin", "").rstrip("/").lower()
+    if origin:
+        return origin in allowed
+    # Same-origin GET/HEAD fetches omit Origin; fall back to Referer.
+    referer = request.headers.get("referer", "").lower()
+    return any(referer == o or referer.startswith(f"{o}/") for o in allowed if referer)
+
+
+def require_api_key(request: Request) -> None:
+    """FastAPI dependency enforcing the policy described in the module docstring."""
+    keys = configured_keys()
+    if not keys:
+        return
+    if request.url.path in EXEMPT_PATHS:
+        return
+    supplied = _extract_key(request)
+    # compare_digest over every key keeps the comparison timing-safe.
+    if supplied and any(hmac.compare_digest(supplied, k) for k in keys):
+        return
+    if _is_exempt_origin(request):
+        return
+    raise HTTPException(
+        status_code=401,
+        detail=(
+            "Missing or invalid API key. Send it as 'Authorization: Bearer "
+            "<key>' or 'X-API-Key: <key>'."
+        ),
+        headers={"WWW-Authenticate": "Bearer"},
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ timezonefinder==8.2.0
 python-dotenv==1.2.1
 pytest==8.4.2
 requests==2.32.5
+httpx==0.28.1
 fpdf2==2.8.4
 uharfbuzz==0.39.3
 orjson==3.11.9

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ python-dotenv==1.2.1
 pytest==8.4.2
 requests==2.32.5
 httpx==0.28.1
+pypdfium2==5.12.1
 fpdf2==2.8.4
 uharfbuzz==0.39.3
 orjson==3.11.9

--- a/backend/server.py
+++ b/backend/server.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Literal, Optional
 
 from dotenv import load_dotenv
-from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse, ORJSONResponse, Response
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from starlette.middleware.cors import CORSMiddleware
 
 from advanced_panchang import compute_detailed_panchang
+from auth import require_api_key
 from ayanamsa import AYANAMSA_OPTIONS
 from calculator import compute_chart
 from muhurta import find_muhurtas, list_purposes
@@ -24,11 +25,16 @@ from transits import compute_transits
 
 ROOT_DIR = Path(__file__).parent
 load_dotenv(ROOT_DIR / ".env")
+# Server-side overrides (API_KEYS, AUTH_EXEMPT_ORIGINS, custom CORS_ORIGINS)
+# live in .env.local: gitignored and never rewritten by setup-vps.sh, so
+# secrets survive deploys. Values here win over .env.
+load_dotenv(ROOT_DIR / ".env.local", override=True)
 
 # ORJSONResponse serializes the ~100 KB panchang payloads several times
 # faster than the stdlib json encoder FastAPI defaults to.
 app = FastAPI(title="Vedic Astrology API", default_response_class=ORJSONResponse)
-api_router = APIRouter(prefix="/api")
+# API-key auth is a no-op until API_KEYS is set in the env - see auth.py.
+api_router = APIRouter(prefix="/api", dependencies=[Depends(require_api_key)])
 
 
 class CalculateRequest(BaseModel):
@@ -498,6 +504,10 @@ def print_pdf(req: PrintPdfRequest):
 
 app.include_router(api_router)
 
+# Third-party browser apps (Flutter Web, React, ...) calling with an API key
+# need their origin added to CORS_ORIGINS. Preflight OPTIONS is answered here,
+# before routing, so it never hits the auth dependency; max_age lets browsers
+# cache the preflight verdict for a day.
 app.add_middleware(
     CORSMiddleware,
     allow_credentials=True,
@@ -505,7 +515,8 @@ app.add_middleware(
         "CORS_ORIGINS", "https://vedicpanchanga.com,http://localhost:3121"
     ).split(","),
     allow_methods=["GET", "POST", "OPTIONS"],
-    allow_headers=["Content-Type"],
+    allow_headers=["Content-Type", "Authorization", "X-API-Key"],
+    max_age=86400,
 )
 
 # Nginx gzips in production; this covers the dev server and any path that

--- a/backend/server.py
+++ b/backend/server.py
@@ -511,9 +511,13 @@ app.include_router(api_router)
 app.add_middleware(
     CORSMiddleware,
     allow_credentials=True,
-    allow_origins=os.environ.get(
-        "CORS_ORIGINS", "https://vedicpanchanga.com,http://localhost:3121"
-    ).split(","),
+    allow_origins=[
+        o.strip()
+        for o in os.environ.get(
+            "CORS_ORIGINS", "https://vedicpanchanga.com,http://localhost:3121"
+        ).split(",")
+        if o.strip()
+    ],
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["Content-Type", "Authorization", "X-API-Key"],
     max_age=86400,

--- a/backend/tests/test_api_auth.py
+++ b/backend/tests/test_api_auth.py
@@ -1,0 +1,146 @@
+"""In-process tests for the optional API-key layer (auth.py) and the CORS
+contract that external browser apps (Flutter Web, React, ...) rely on.
+
+Uses FastAPI's TestClient, so no running server is needed. API_KEYS /
+AUTH_EXEMPT_ORIGINS are read per-request by auth.py, which is what makes
+monkeypatch.setenv work here without reloading the app.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server import app
+
+KEY = "test-key-abc123"
+SECOND_KEY = "second-key-xyz789"
+
+# Cheap authenticated endpoint - static payload, no ephemeris math.
+PROBE = "/api/ayanamsa-options"
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_on(monkeypatch):
+    # Space after the comma on purpose: keys must be stripped when parsed.
+    monkeypatch.setenv("API_KEYS", f"{KEY}, {SECOND_KEY}")
+
+
+@pytest.fixture
+def auth_off(monkeypatch):
+    monkeypatch.delenv("API_KEYS", raising=False)
+
+
+# ── auth disabled (default) ──────────────────────────────────────────────
+def test_open_access_when_no_keys_configured(client, auth_off):
+    assert client.get(PROBE).status_code == 200
+
+
+def test_empty_api_keys_var_means_open(client, monkeypatch):
+    monkeypatch.setenv("API_KEYS", "  ,  ")
+    assert client.get(PROBE).status_code == 200
+
+
+# ── auth enabled: key checks ─────────────────────────────────────────────
+def test_401_without_key(client, auth_on):
+    r = client.get(PROBE)
+    assert r.status_code == 401
+    assert r.headers.get("www-authenticate") == "Bearer"
+
+
+def test_bearer_key_accepted(client, auth_on):
+    r = client.get(PROBE, headers={"Authorization": f"Bearer {KEY}"})
+    assert r.status_code == 200
+
+
+def test_x_api_key_accepted(client, auth_on):
+    r = client.get(PROBE, headers={"X-API-Key": KEY})
+    assert r.status_code == 200
+
+
+def test_second_key_in_csv_accepted(client, auth_on):
+    r = client.get(PROBE, headers={"X-API-Key": SECOND_KEY})
+    assert r.status_code == 200
+
+
+def test_wrong_key_rejected(client, auth_on):
+    r = client.get(PROBE, headers={"X-API-Key": "not-a-real-key"})
+    assert r.status_code == 401
+
+
+def test_wrong_bearer_scheme_rejected(client, auth_on):
+    r = client.get(PROBE, headers={"Authorization": f"Basic {KEY}"})
+    assert r.status_code == 401
+
+
+# ── auth enabled: exemptions ─────────────────────────────────────────────
+def test_liveness_paths_stay_open(client, auth_on):
+    assert client.get("/api/").status_code == 200
+    assert client.get("/api/health").status_code in (200, 503)
+
+
+def test_exempt_origin_needs_no_key(client, auth_on):
+    # localhost:3121 is in the default AUTH_EXEMPT_ORIGINS (Vite dev server).
+    r = client.get(PROBE, headers={"Origin": "http://localhost:3121"})
+    assert r.status_code == 200
+
+
+def test_referer_fallback_for_same_origin_get(client, auth_on):
+    # Same-origin GET fetches omit Origin; the Referer prefix must match.
+    r = client.get(PROBE, headers={"Referer": "https://vedicpanchanga.com/panchang"})
+    assert r.status_code == 200
+
+
+def test_unknown_origin_still_needs_key(client, auth_on):
+    headers = {"Origin": "https://myexampledomain.com"}
+    assert client.get(PROBE, headers=headers).status_code == 401
+    headers["X-API-Key"] = KEY
+    assert client.get(PROBE, headers=headers).status_code == 200
+
+
+def test_custom_exempt_origins_override(client, auth_on, monkeypatch):
+    monkeypatch.setenv("AUTH_EXEMPT_ORIGINS", "https://partner.example")
+    r = client.get(PROBE, headers={"Origin": "https://partner.example"})
+    assert r.status_code == 200
+    # The default exemptions are replaced, not extended.
+    r = client.get(PROBE, headers={"Origin": "http://localhost:3121"})
+    assert r.status_code == 401
+
+
+# ── CORS preflight contract ──────────────────────────────────────────────
+def test_preflight_succeeds_without_key(client, auth_on):
+    """OPTIONS /api/calculate must succeed with the CORS headers browser apps
+    need, even with auth enabled - preflights never carry credentials."""
+    r = client.options(
+        "/api/calculate",
+        headers={
+            # localhost:3121 is in the dev CORS_ORIGINS allowlist (.env).
+            "Origin": "http://localhost:3121",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type,x-api-key",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers["access-control-allow-origin"] == "http://localhost:3121"
+    assert "POST" in r.headers["access-control-allow-methods"]
+    allow_headers = r.headers["access-control-allow-headers"].lower()
+    assert "authorization" in allow_headers
+    assert "x-api-key" in allow_headers
+    assert r.headers["access-control-max-age"] == "86400"
+
+
+def test_preflight_rejects_origin_outside_cors_allowlist(client, auth_on):
+    r = client.options(
+        "/api/calculate",
+        headers={
+            "Origin": "https://not-in-allowlist.example",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert r.status_code == 400
+    assert "access-control-allow-origin" not in r.headers


### PR DESCRIPTION
## Summary

Lets external clients (mobile apps, other domains) call the API with an API key, while keeping the public site fully working without one. A second commit cleans up the env-file handling and tooling issues found along the way.

### API-key auth (commit 1)

- `backend/auth.py`: `API_KEYS` env (comma-separated) enforced on all `/api/*` routes via a router-level dependency. Unset = fully open API, so nothing changes in prod until keys are configured.
- Keys accepted as `Authorization: Bearer <key>` or `X-API-Key: <key>` (timing-safe comparison).
- Own-site requests stay keyless: `Origin`/`Referer` matching `AUTH_EXEMPT_ORIGINS` (default: vedicpanchanga.com + localhost dev) skips the check; `/api/` and `/api/health` stay open for monitoring probes.
- CORS: allowed headers now `Content-Type, Authorization, X-API-Key`; preflight verdict cached for 24h (`max_age=86400`). Preflight `OPTIONS` is answered by CORSMiddleware before auth runs, so browser apps (Flutter Web, React, Angular, Vue) work without a proxy once their origin is added to `CORS_ORIGINS`.
- Server-side keys live in `backend/.env.local` (gitignored, loaded over `.env` with override) so they survive the `.env` rewrite done by `setup-vps.sh` on every deploy.

### Env-file and tooling cleanup (commit 2)

- **Untracked `backend/.env`** (`git rm --cached`): it was tracked yet listed in `.gitignore`, and `setup-vps.sh` rewrites it on the VPS, so any commit touching it broke `git pull` deploys. Dev config is now documented in the tracked `backend/.env.example`, seeded to `.env` by `make install`.
- **Makefile**: venv creation prefers `python3.14` over bare `python3` (CommandLineTools 3.9 on some Macs, which once produced a broken hybrid venv).
- **`server.py`**: `CORS_ORIGINS` parsing now strips whitespace and empties, so spaces after commas in an env file don't silently break origin matching.
- **`requirements.txt`**: pinned `pypdfium2` - an undeclared test dependency without which a fresh install silently skips the 7 PDF render tests. Also adds `httpx` (FastAPI TestClient dep).

## Deploy note (one-time)

The VPS's `backend/.env` is locally modified (rewritten by `setup-vps.sh`), so the pull that deletes it from git needs a clean file first:

```bash
git checkout -- backend/.env && git pull && sudo bash infra/setup-vps.sh
```

After that, `.env` is untracked on the server and the conflict class is gone for good.

## Enabling API keys on the server

1. Create `backend/.env.local` with `API_KEYS=<key1>,<key2>` (generate: `python3 -c "import secrets; print(secrets.token_urlsafe(32))"`).
2. For browser-based third parties, append their origin to `CORS_ORIGINS` there too.
3. `sudo systemctl restart panchanga-backend`.

## Notes

- The origin exemption trusts browser-set headers, which non-browser tools can spoof. The API was fully public before, so this does not weaken anything; keys grant and track third-party access rather than harden the first-party path.

## Testing

- 15 new tests in `backend/tests/test_api_auth.py` (key checks, exemptions, CORS preflight contract, disallowed-origin preflight rejection).
- Full backend suite on a fresh Python 3.14 venv: 319 passed, 0 skipped. `ruff check` and `ruff format --check` clean.