### PR TITLE
Remove dead code in advanced_panchang and calculator

### DIFF
--- a/backend/advanced_panchang.py
+++ b/backend/advanced_panchang.py
@@ -502,28 +502,6 @@ def _nakshatras_with_bounds(start_jd: float, end_jd: float) -> List[Dict]:
         else:
             break
     return out
-    out = []
-    cursor = start_jd
-    safety = 0
-    while cursor < end_jd and safety < 6:
-        safety += 1
-        _, m = _sun_moon_sid(cursor)
-        nak_idx = int(m // NAK_SPAN)
-        nak_end_deg = (nak_idx + 1) * NAK_SPAN
-        end = _find_angle_time(cursor, nak_end_deg, "moon", max_days=2.0)
-        ends = min(end, end_jd) if end else end_jd
-        out.append(
-            {
-                "name": NAKSHATRAS[nak_idx],
-                "index": nak_idx + 1,
-                "ends_at_jd": ends,
-            }
-        )
-        if end and end < end_jd:
-            cursor = end + 1e-5
-        else:
-            break
-    return out
 
 
 def _nakshatras_in_window(start_jd: float, end_jd: float) -> List[Dict]:

--- a/backend/calculator.py
+++ b/backend/calculator.py
@@ -567,15 +567,3 @@ def _is_combust(name: str, lon: float, sun_lon: float, retro: bool) -> bool:
     if diff > 180:
         diff = 360 - diff
     return diff <= _COMBUST_ORB
-
-
-def _build_house_map(
-    planets: Dict[str, Dict[str, Any]], asc_sign: int, key: str
-) -> Dict[int, List[str]]:
-    """Return dict house (1-12) -> list of planet abbreviations, using whole-sign houses."""
-    houses: Dict[int, List[str]] = {i: [] for i in range(1, 13)}
-    for p in planets.values():
-        sign = p[key]
-        house = ((sign - asc_sign) % 12) + 1
-        houses[house].append(p["abbr"])
-    return houses


### PR DESCRIPTION
## Summary

Pure dead-code removal, 34 deleted lines, zero behavior change.

- `advanced_panchang.py`: `_nakshatras_with_bounds` carried ~22 unreachable lines after its `return out` - an orphaned earlier version of the same loop (known smell, first noted while working on #48).
- `calculator.py`: `_build_house_map` was defined but never called from anywhere. `git log -S` shows exactly one commit ever touched it - it was added and never wired up.

Found via an AST scan of the whole backend for (a) statements after `return`/`raise` in the same block and (b) module-private functions with zero references; these two were the only hits.

Deliberately **not** included: the `_moonsigns_in_window` / `_nakshatra_padas_in_window` end-clipping inconsistency - that is a behavior change to panchang output and needs separate review (same pattern as baa5c12).

## Testing

Full backend suite: 304 passed, including the Kelowna panchang reference anchors, confirming output is byte-identical. `ruff check` and `ruff format --check` clean.